### PR TITLE
Fix GUI and item textures

### DIFF
--- a/pipi_mod/src/main/java/com/pipimod/energy/MetalFillerScreen.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/MetalFillerScreen.java
@@ -7,8 +7,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 
 public class MetalFillerScreen extends ContainerScreen<MetalFillerContainer> {
-    // use vanilla furnace GUI since custom texture was removed
-    private static final ResourceLocation TEXTURE = new ResourceLocation("minecraft", "textures/gui/container/furnace.png");
+    private static final ResourceLocation TEXTURE = new ResourceLocation(EnergyMod.MODID, "textures/gui/metal_filler_screen.png");
 
     public MetalFillerScreen(MetalFillerContainer container, PlayerInventory inv, ITextComponent title) {
         super(container, inv, title);

--- a/pipi_mod/src/main/resources/assets/energymod/models/item/cast_iron_ingot.json
+++ b/pipi_mod/src/main/resources/assets/energymod/models/item/cast_iron_ingot.json
@@ -1,6 +1,6 @@
 {
   "parent": "item/generated",
   "textures": {
-    "layer0": "energymod:item/black"
+    "layer0": "energymod:item/cast_iron_ingot"
   }
 }

--- a/pipi_mod/src/main/resources/assets/energymod/models/item/copper_ingot.json
+++ b/pipi_mod/src/main/resources/assets/energymod/models/item/copper_ingot.json
@@ -1,6 +1,6 @@
 {
   "parent": "item/generated",
   "textures": {
-    "layer0": "energymod:item/black"
+    "layer0": "energymod:item/copper_ingot"
   }
 }

--- a/pipi_mod/src/main/resources/assets/energymod/models/item/lead_ingot.json
+++ b/pipi_mod/src/main/resources/assets/energymod/models/item/lead_ingot.json
@@ -1,6 +1,6 @@
 {
   "parent": "item/generated",
   "textures": {
-    "layer0": "energymod:item/black"
+    "layer0": "energymod:item/lead_ingot"
   }
 }

--- a/pipi_mod/src/main/resources/assets/energymod/models/item/osmium_ingot.json
+++ b/pipi_mod/src/main/resources/assets/energymod/models/item/osmium_ingot.json
@@ -1,6 +1,6 @@
 {
   "parent": "item/generated",
   "textures": {
-    "layer0": "energymod:item/black"
+    "layer0": "energymod:item/osmium_ingot"
   }
 }


### PR DESCRIPTION
## Summary
- use Metal Filler custom GUI texture
- link ingot item models to their textures

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68643edf329c832c8a8bd0acc185bbce