### PR TITLE
Fix wind turbine placement orientation

### DIFF
--- a/pipi_mod/src/main/java/com/pipimod/energy/EnergyWireBlock.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/EnergyWireBlock.java
@@ -123,13 +123,20 @@ public class EnergyWireBlock extends Block {
             if (te instanceof WireBlockEntity) {
                 WireBlockEntity wire = (WireBlockEntity) te;
                 if (wire.getEnergyStored() > 0) {
-                    entity.hurt(EnergyDamageSources.ELECTRIC_SHOCK, 2.0F);
-                    Vector3d dir = entity.position().subtract(Vector3d.atCenterOf(pos)).normalize().scale(1.2);
-                    entity.push(dir.x, 0.5, dir.z);
+                    applyElectricShock((LivingEntity) entity, pos);
                 }
             }
         }
         super.entityInside(state, world, pos, entity);
+    }
+
+    private static void applyElectricShock(LivingEntity entity, BlockPos pos) {
+        // Inflict constant damage bypassing armor
+        entity.hurt(EnergyDamageSources.ELECTRIC_SHOCK, 2.0F);
+
+        // Knock the entity away from the wire
+        Vector3d vec = entity.position().subtract(Vector3d.atCenterOf(pos)).normalize();
+        entity.push(vec.x * 0.7, 0.4, vec.z * 0.7);
     }
 
     @Override

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineBlock.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineBlock.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.material.Material;
 import net.minecraft.state.EnumProperty;
+import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.state.Property;
 import net.minecraft.tileentity.TileEntity;
@@ -14,6 +15,8 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.Direction;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
 import net.minecraft.entity.LivingEntity;
@@ -35,6 +38,7 @@ public class WindTurbineBlock extends Block {
     }
 
     public static final EnumProperty<Part> PART = EnumProperty.create("part", Part.class);
+    public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 
     private static final VoxelShape BASE_SHAPE = Block.box(0, 0, 0, 16, 16, 16);
     private static final VoxelShape MIDDLE_SHAPE = Block.box(2, 0, 2, 14, 16, 14);
@@ -46,7 +50,9 @@ public class WindTurbineBlock extends Block {
 
     public WindTurbineBlock() {
         super(Properties.of(Material.METAL).strength(2f).noOcclusion());
-        this.registerDefaultState(this.stateDefinition.any().setValue(PART, Part.BASE));
+        this.registerDefaultState(this.stateDefinition.any()
+                .setValue(PART, Part.BASE)
+                .setValue(FACING, Direction.NORTH));
     }
 
     @Nullable
@@ -56,15 +62,17 @@ public class WindTurbineBlock extends Block {
         if (pos.getY() < ctx.getLevel().getMaxBuildHeight() - 2 &&
                 ctx.getLevel().getBlockState(pos.above()).isAir() &&
                 ctx.getLevel().getBlockState(pos.above(2)).isAir()) {
-            return this.defaultBlockState();
+            return this.defaultBlockState()
+                    .setValue(FACING, ctx.getHorizontalDirection().getOpposite());
         }
         return null;
     }
 
     @Override
     public void setPlacedBy(World world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack) {
-        world.setBlock(pos.above(), this.defaultBlockState().setValue(PART, Part.MIDDLE), 3);
-        world.setBlock(pos.above(2), this.defaultBlockState().setValue(PART, Part.TOP), 3);
+        Direction facing = state.getValue(FACING);
+        world.setBlock(pos.above(), this.defaultBlockState().setValue(PART, Part.MIDDLE).setValue(FACING, facing), 3);
+        world.setBlock(pos.above(2), this.defaultBlockState().setValue(PART, Part.TOP).setValue(FACING, facing), 3);
     }
 
     @Override
@@ -87,7 +95,7 @@ public class WindTurbineBlock extends Block {
 
     @Override
     protected void createBlockStateDefinition(StateContainer.Builder<Block, BlockState> builder) {
-        builder.add(PART);
+        builder.add(PART, FACING);
     }
 
     @Override

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
@@ -31,7 +31,7 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
 
         // Static arm connecting the hub to the tower
         this.arm = new ModelRenderer(64, 64, 8, 22);
-        this.arm.addBox(-0.5F, -0.5F, -3.0F, 1, 1, 3, 0.0F);
+        this.arm.addBox(-0.5F, -0.5F, -4.0F, 1, 1, 4, 0.0F);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
         // Position rotor in front of the top section
         ms.translate(0.5D, 2.9375D, 0.5D);
         ms.mulPose(Vector3f.YP.rotationDegrees(facing.toYRot()));
-        ms.translate(0.0D, 0.0D, -0.5D);
+        ms.translate(0.0D, 0.0D, 0.375D);
 
         IVertexBuilder vb = buffer.getBuffer(RenderType.entityCutout(TEXTURE));
 

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
@@ -15,12 +15,23 @@ import net.minecraft.util.Direction;
 public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntity> {
     private static final ResourceLocation TEXTURE = new ResourceLocation(EnergyMod.MODID, "textures/block/wind_turbine_turbne.png");
     private final ModelRenderer blade;
+    private final ModelRenderer hub;
+    private final ModelRenderer arm;
     
     public WindTurbineRenderer(TileEntityRendererDispatcher dispatcher) {
         super(dispatcher);
         // Single thin blade rendered three times with rotation
         this.blade = new ModelRenderer(64, 64, 0, 0);
-        this.blade.addBox(-0.5F, -8.0F, 0.0F, 1, 16, 2, 0.0F);
+        // Extend blade length to 20px
+        this.blade.addBox(-0.5F, -10.0F, 0.0F, 1, 20, 2, 0.0F);
+
+        // Central hub that rotates with the blades
+        this.hub = new ModelRenderer(64, 64, 0, 22);
+        this.hub.addBox(-1.0F, -1.0F, -1.0F, 2, 2, 2, 0.0F);
+
+        // Static arm connecting the hub to the tower
+        this.arm = new ModelRenderer(64, 64, 8, 22);
+        this.arm.addBox(-0.5F, -0.5F, -3.0F, 1, 1, 3, 0.0F);
     }
 
     @Override
@@ -32,11 +43,18 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
         // Position rotor in front of the top section
         ms.translate(0.5D, 2.9375D, 0.5D);
         ms.mulPose(Vector3f.YP.rotationDegrees(facing.toYRot()));
-        ms.translate(0.0D, 0.0D, -0.75D);
+        ms.translate(0.0D, 0.0D, -0.5D);
+
+        IVertexBuilder vb = buffer.getBuffer(RenderType.entityCutout(TEXTURE));
+
+        // Render static arm that connects rotor to tower
+        arm.render(ms, vb, light, OverlayTexture.NO_OVERLAY);
 
         // Rotate blades around the facing axis
         ms.mulPose(Vector3f.ZP.rotationDegrees(angle));
-        IVertexBuilder vb = buffer.getBuffer(RenderType.entityCutout(TEXTURE));
+
+        // Render hub
+        hub.render(ms, vb, light, OverlayTexture.NO_OVERLAY);
 
         for (int i = 0; i < 3; i++) {
             ms.pushPose();

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
@@ -28,13 +28,13 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
     @Override
     public void render(WindTurbineTileEntity tile, float partialTicks, MatrixStack ms, IRenderTypeBuffer buffer, int light, int overlay) {
         ms.pushPose();
-        ms.translate(0.5D, 3.0D, 0.5D);
-        float angle = tile.getRotation();
         Direction facing = tile.getBlockState().getValue(WindTurbineBlock.FACING);
-        Direction axis = facing.getClockWise();
-        float yaw = axis.toYRot() - 90.0F;
-        ms.mulPose(Vector3f.YP.rotationDegrees(yaw));
-        ms.mulPose(Vector3f.ZP.rotationDegrees(90.0F));
+        float angle = tile.getRotation();
+        double offset = 0.75D;
+        ms.translate(0.5D + facing.getStepX() * offset,
+                     3.0D,
+                     0.5D + facing.getStepZ() * offset);
+        ms.mulPose(Vector3f.YP.rotationDegrees(facing.toYRot()));
         ms.mulPose(Vector3f.XP.rotationDegrees(angle));
         IVertexBuilder vb = buffer.getBuffer(RenderType.entityCutout(TEXTURE));
         blade1.render(ms, vb, light, OverlayTexture.NO_OVERLAY);

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.vector.Vector3f;
+import net.minecraft.util.Direction;
 
 public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntity> {
     private static final ResourceLocation TEXTURE = new ResourceLocation(EnergyMod.MODID, "textures/block/wind_turbine_turbne.png");
@@ -29,6 +30,10 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
         ms.pushPose();
         ms.translate(0.5D, 3.0D, 0.5D);
         float angle = tile.getRotation();
+        Direction facing = tile.getBlockState().getValue(WindTurbineBlock.FACING);
+        Direction axis = facing.getClockWise();
+        float yaw = axis.toYRot() - 90.0F;
+        ms.mulPose(Vector3f.YP.rotationDegrees(yaw));
         ms.mulPose(Vector3f.ZP.rotationDegrees(90.0F));
         ms.mulPose(Vector3f.XP.rotationDegrees(angle));
         IVertexBuilder vb = buffer.getBuffer(RenderType.entityCutout(TEXTURE));

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
@@ -30,12 +30,12 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
         ms.pushPose();
         Direction facing = tile.getBlockState().getValue(WindTurbineBlock.FACING);
         float angle = tile.getRotation();
-        double offset = 0.75D;
-        ms.translate(0.5D + facing.getStepX() * offset,
-                     3.0D,
-                     0.5D + facing.getStepZ() * offset);
+
+        ms.translate(0.5D, 3.0D, 0.5D);
         ms.mulPose(Vector3f.YP.rotationDegrees(facing.toYRot()));
-        ms.mulPose(Vector3f.XP.rotationDegrees(angle));
+        ms.translate(0.0D, 0.0D, -0.55D);
+        ms.mulPose(Vector3f.XP.rotationDegrees(90.0F));
+        ms.mulPose(Vector3f.ZP.rotationDegrees(angle));
         IVertexBuilder vb = buffer.getBuffer(RenderType.entityCutout(TEXTURE));
         blade1.render(ms, vb, light, OverlayTexture.NO_OVERLAY);
         blade2.render(ms, vb, light, OverlayTexture.NO_OVERLAY);

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
@@ -20,9 +20,11 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
     public WindTurbineRenderer(TileEntityRendererDispatcher dispatcher) {
         super(dispatcher);
         this.blade1 = new ModelRenderer(64, 64, 0, 0);
-        this.blade1.addBox(-12.0F, -1.0F, -1.0F, 24, 2, 2, 0.0F);
-        this.blade2 = new ModelRenderer(64, 64, 0, 4);
-        this.blade2.addBox(-1.0F, -1.0F, -12.0F, 2, 2, 24, 0.0F);
+        // Vertical blade running north-south
+        this.blade1.addBox(-1.0F, -12.0F, -12.0F, 2, 24, 24, 0.0F);
+        this.blade2 = new ModelRenderer(64, 64, 0, 48);
+        // Vertical blade running east-west
+        this.blade2.addBox(-12.0F, -12.0F, -1.0F, 24, 24, 2, 0.0F);
     }
 
     @Override

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
@@ -31,11 +31,13 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
         Direction facing = tile.getBlockState().getValue(WindTurbineBlock.FACING);
         float angle = tile.getRotation();
 
-        ms.translate(0.5D, 3.0D, 0.5D);
+        // Position at the front of the top section
+        ms.translate(0.5D, 2.9375D, 0.5D);
         ms.mulPose(Vector3f.YP.rotationDegrees(facing.toYRot()));
-        ms.translate(0.0D, 0.0D, -0.55D);
-        ms.mulPose(Vector3f.XP.rotationDegrees(90.0F));
-        ms.mulPose(Vector3f.ZP.rotationDegrees(angle));
+        ms.translate(0.0D, 0.0D, -0.5D);
+
+        // Spin around the vertical (Y) axis
+        ms.mulPose(Vector3f.YP.rotationDegrees(angle));
         IVertexBuilder vb = buffer.getBuffer(RenderType.entityCutout(TEXTURE));
         blade1.render(ms, vb, light, OverlayTexture.NO_OVERLAY);
         blade2.render(ms, vb, light, OverlayTexture.NO_OVERLAY);

--- a/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
+++ b/pipi_mod/src/main/java/com/pipimod/energy/WindTurbineRenderer.java
@@ -14,17 +14,13 @@ import net.minecraft.util.Direction;
 
 public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntity> {
     private static final ResourceLocation TEXTURE = new ResourceLocation(EnergyMod.MODID, "textures/block/wind_turbine_turbne.png");
-    private final ModelRenderer blade1;
-    private final ModelRenderer blade2;
-
+    private final ModelRenderer blade;
+    
     public WindTurbineRenderer(TileEntityRendererDispatcher dispatcher) {
         super(dispatcher);
-        this.blade1 = new ModelRenderer(64, 64, 0, 0);
-        // Vertical blade running north-south
-        this.blade1.addBox(-1.0F, -12.0F, -12.0F, 2, 24, 24, 0.0F);
-        this.blade2 = new ModelRenderer(64, 64, 0, 48);
-        // Vertical blade running east-west
-        this.blade2.addBox(-12.0F, -12.0F, -1.0F, 24, 24, 2, 0.0F);
+        // Single thin blade rendered three times with rotation
+        this.blade = new ModelRenderer(64, 64, 0, 0);
+        this.blade.addBox(-0.5F, -8.0F, 0.0F, 1, 16, 2, 0.0F);
     }
 
     @Override
@@ -33,16 +29,21 @@ public class WindTurbineRenderer extends TileEntityRenderer<WindTurbineTileEntit
         Direction facing = tile.getBlockState().getValue(WindTurbineBlock.FACING);
         float angle = tile.getRotation();
 
-        // Position at the front of the top section
+        // Position rotor in front of the top section
         ms.translate(0.5D, 2.9375D, 0.5D);
         ms.mulPose(Vector3f.YP.rotationDegrees(facing.toYRot()));
-        ms.translate(0.0D, 0.0D, -0.5D);
+        ms.translate(0.0D, 0.0D, -0.75D);
 
-        // Spin around the vertical (Y) axis
-        ms.mulPose(Vector3f.YP.rotationDegrees(angle));
+        // Rotate blades around the facing axis
+        ms.mulPose(Vector3f.ZP.rotationDegrees(angle));
         IVertexBuilder vb = buffer.getBuffer(RenderType.entityCutout(TEXTURE));
-        blade1.render(ms, vb, light, OverlayTexture.NO_OVERLAY);
-        blade2.render(ms, vb, light, OverlayTexture.NO_OVERLAY);
+
+        for (int i = 0; i < 3; i++) {
+            ms.pushPose();
+            ms.mulPose(Vector3f.ZP.rotationDegrees(i * 120f));
+            blade.render(ms, vb, light, OverlayTexture.NO_OVERLAY);
+            ms.popPose();
+        }
         ms.popPose();
     }
 }

--- a/pipi_mod/src/main/resources/assets/energymod/blockstates/wind_turbine.json
+++ b/pipi_mod/src/main/resources/assets/energymod/blockstates/wind_turbine.json
@@ -1,7 +1,18 @@
 {
   "variants": {
-    "part=base": { "model": "energymod:block/wind_turbine" },
-    "part=middle": { "model": "energymod:block/wind_turbine_middle" },
-    "part=top": { "model": "energymod:block/wind_turbine_top" }
+    "part=base,facing=north": { "model": "energymod:block/wind_turbine", "y": 180 },
+    "part=base,facing=east":  { "model": "energymod:block/wind_turbine", "y": 90 },
+    "part=base,facing=south": { "model": "energymod:block/wind_turbine", "y": 0 },
+    "part=base,facing=west":  { "model": "energymod:block/wind_turbine", "y": 270 },
+
+    "part=middle,facing=north": { "model": "energymod:block/wind_turbine_middle", "y": 180 },
+    "part=middle,facing=east":  { "model": "energymod:block/wind_turbine_middle", "y": 90 },
+    "part=middle,facing=south": { "model": "energymod:block/wind_turbine_middle", "y": 0 },
+    "part=middle,facing=west":  { "model": "energymod:block/wind_turbine_middle", "y": 270 },
+
+    "part=top,facing=north": { "model": "energymod:block/wind_turbine_top", "y": 180 },
+    "part=top,facing=east":  { "model": "energymod:block/wind_turbine_top", "y": 90 },
+    "part=top,facing=south": { "model": "energymod:block/wind_turbine_top", "y": 0 },
+    "part=top,facing=west":  { "model": "energymod:block/wind_turbine_top", "y": 270 }
   }
 }

--- a/pipi_mod/src/main/resources/assets/energymod/models/item/wind_turbine.json
+++ b/pipi_mod/src/main/resources/assets/energymod/models/item/wind_turbine.json
@@ -1,3 +1,15 @@
 {
-  "parent": "energymod:block/wind_turbine_tower"
+  "parent": "energymod:block/wind_turbine_tower",
+  "display": {
+    "thirdperson": {
+      "rotation": [ 10, -45, 170 ],
+      "translation": [ 0, 2, 0 ],
+      "scale": [ 0.35, 0.35, 0.35 ]
+    },
+    "firstperson": {
+      "rotation": [ 0, -45, 0 ],
+      "translation": [ 1, 1, 0 ],
+      "scale": [ 0.35, 0.35, 0.35 ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- orient wind turbine block to face the player when placed
- rotate blades based on block facing
- update blockstate variants for orientation

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68658f2c0414832ca371fd1817917e5b